### PR TITLE
Fix domain suggestion normalization output

### DIFF
--- a/src/app/api/projects/[id]/domains/suggest/route.ts
+++ b/src/app/api/projects/[id]/domains/suggest/route.ts
@@ -29,11 +29,27 @@ function stripCodeFences(text: string) {
 
 function normalizeList(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw.map((x) => String(x)).filter(Boolean);
+
+  const toStrings = (value: unknown): string[] => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? [trimmed] : [];
+    }
+    if (Array.isArray(value)) {
+      return value.flatMap(toStrings);
+    }
+    if (value && typeof value === "object") {
+      return Object.values(value).flatMap(toStrings);
+    }
+    return [];
+  };
+
   if (typeof raw !== "string") return [];
   let text = stripCodeFences(raw);
   try {
-    const j = JSON.parse(text);
-    if (Array.isArray(j)) return j.map((x) => String(x)).filter(Boolean);
+    const parsed = JSON.parse(text);
+    const list = toStrings(parsed);
+    if (list.length) return list;
   } catch {}
   return text
     .split(/\r?\n|,|;/)

--- a/src/components/projects/DomainCreateDialog.tsx
+++ b/src/components/projects/DomainCreateDialog.tsx
@@ -8,6 +8,18 @@ import { useRouter } from "next/navigation";
 /** Normalise une réponse variée (```json …```, CSV, listes, etc.) en tableau de chaînes */
 function normalizeList(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw.map((x) => String(x)).filter(Boolean);
+  const toStrings = (value: unknown): string[] => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? [trimmed] : [];
+    }
+    if (Array.isArray(value)) return value.flatMap(toStrings);
+    if (value && typeof value === "object") {
+      return Object.values(value).flatMap(toStrings);
+    }
+    return [];
+  };
+
   if (typeof raw !== "string") return [];
   let text = raw.trim();
 
@@ -16,8 +28,9 @@ function normalizeList(raw: unknown): string[] {
 
   // tente JSON direct
   try {
-    const j = JSON.parse(text);
-    if (Array.isArray(j)) return j.map((x) => String(x)).filter(Boolean);
+    const parsed = JSON.parse(text);
+    const list = toStrings(parsed);
+    if (list.length) return list;
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- handle nested JSON objects when normalizing domain suggestion responses on the API route
- mirror the recursive normalization in the domain creation dialog so UI suggestions only display raw values

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d506d78afc8330b18f248f59f17c4a