### PR TITLE
Enhance dashboard, domain insights, analysis history, and admin stats

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,10 +1,257 @@
-export default function DashboardPage() {
+import { PrismaClient } from "@prisma/client";
+import { AnalysisReportSchema } from "@/types/analysis";
+import { summarizeAnalysis } from "@/lib/analysisSummary";
+
+const prisma = new PrismaClient();
+
+function parseCompetitors(value: string): string[] {
+  try {
+    const arr = JSON.parse(value);
+    return Array.isArray(arr) ? arr.map((item) => String(item)).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function formatRelative(iso: string) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export default async function DashboardPage() {
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 1000 * 60 * 60 * 24 * 30);
+
+  const [
+    projectCount,
+    domainCount,
+    analysisCount,
+    analysesLast30Days,
+    recentAnalyses,
+    domainRows,
+    recentProjects,
+  ] = await Promise.all([
+    prisma.project.count(),
+    prisma.domain.count(),
+    prisma.projectAnalysis.count(),
+    prisma.projectAnalysis.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
+    prisma.projectAnalysis.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        createdAt: true,
+        report: true,
+        project: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.domain.findMany({
+      select: {
+        id: true,
+        name: true,
+        competitors: true,
+        updatedAt: true,
+        project: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.project.findMany({
+      orderBy: { updatedAt: "desc" },
+      take: 3,
+      select: {
+        id: true,
+        name: true,
+        createdAt: true,
+        updatedAt: true,
+        domains: { select: { id: true } },
+        analyses: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { createdAt: true },
+        },
+      },
+    }),
+  ]);
+
+  const competitorFrequency = new Map<string, number>();
+  const coverage = domainRows.map((domain) => {
+    const competitors = parseCompetitors(domain.competitors);
+    competitors.forEach((name) => {
+      const key = name.trim();
+      if (!key) return;
+      competitorFrequency.set(key, (competitorFrequency.get(key) ?? 0) + 1);
+    });
+    return {
+      id: domain.id,
+      name: domain.name,
+      projectName: domain.project.name,
+      competitorCount: competitors.length,
+      updatedAt: domain.updatedAt.toISOString(),
+    };
+  });
+
+  const topCompetitors = Array.from(competitorFrequency.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+
+  const analyses = recentAnalyses
+    .map((row) => {
+      const parsed = AnalysisReportSchema.safeParse(row.report);
+      if (!parsed.success) return null;
+      const summary = summarizeAnalysis(parsed.data);
+      return {
+        id: row.id,
+        projectName: row.project.name,
+        createdAt: row.createdAt.toISOString(),
+        summary,
+      };
+    })
+    .filter((entry): entry is {
+      id: string;
+      projectName: string;
+      createdAt: string;
+      summary: ReturnType<typeof summarizeAnalysis>;
+    } => Boolean(entry));
+
+  const domainsWithoutCompetitors = coverage.filter((item) => item.competitorCount === 0).length;
+  const domainsLightCoverage = coverage
+    .filter((item) => item.competitorCount > 0 && item.competitorCount < 3)
+    .slice(0, 4);
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Tableau de bord</h1>
-      <p className="text-sm text-gray-600 dark:text-zinc-400">
-        Bienvenue sur <strong>Zetruc Pulse</strong>.
-      </p>
+    <div className="space-y-8">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <StatCard label="Projets actifs" value={projectCount} helper="Nombre total de marques suivies" />
+        <StatCard
+          label="Domaines cartographiés"
+          value={domainCount}
+          helper={`Dont ${domainsWithoutCompetitors} à enrichir`}
+        />
+        <StatCard
+          label="Analyses générées"
+          value={analysisCount}
+          helper={`${analysesLast30Days} sur les 30 derniers jours`}
+        />
+        <StatCard
+          label="Concurrents référencés"
+          value={competitorFrequency.size}
+          helper="Entrées uniques toutes marques"
+        />
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-4">
+          <div className="rounded-2xl border p-5 dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">Dernières analyses</h2>
+            {analyses.length === 0 ? (
+              <p className="mt-4 text-sm text-muted-foreground">
+                Aucune analyse n’a encore été générée.
+              </p>
+            ) : (
+              <ul className="mt-4 space-y-3 text-sm">
+                {analyses.map((item) => (
+                  <li key={item.id} className="rounded-xl border p-3 dark:border-zinc-800">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{item.projectName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Générée le {formatRelative(item.summary.generatedAt)} • {item.summary.mentionRate}% de présence • {item.summary.competitorCount} concurrents cités
+                        </p>
+                      </div>
+                      <span className="text-xs font-medium text-muted-foreground">{item.summary.sentiment}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="rounded-2xl border p-5 dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">Focus veille concurrentielle</h2>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <div>
+                <h3 className="text-sm font-semibold">Top concurrents cités</h3>
+                {topCompetitors.length === 0 ? (
+                  <p className="mt-2 text-sm text-muted-foreground">Aucun concurrent recensé pour le moment.</p>
+                ) : (
+                  <ul className="mt-2 space-y-2 text-sm">
+                    {topCompetitors.map(([name, score]) => (
+                      <li
+                        key={name}
+                        className="flex items-center justify-between rounded-lg border border-dashed p-2 dark:border-zinc-700"
+                      >
+                        <span>{name}</span>
+                        <span className="text-xs text-muted-foreground">{score} domaines</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold">Domaines à consolider</h3>
+                {domainsLightCoverage.length === 0 ? (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Tous les domaines disposent d’au moins 3 concurrents suivis.
+                  </p>
+                ) : (
+                  <ul className="mt-2 space-y-2 text-sm">
+                    {domainsLightCoverage.map((item) => (
+                      <li key={item.id} className="rounded-lg border border-dashed p-2 dark:border-zinc-700">
+                        <p className="font-medium">{item.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {item.projectName} • {item.competitorCount} concurrents suivis
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border p-5 dark:border-zinc-800">
+            <h2 className="text-lg font-semibold">Projets en activité</h2>
+            <ul className="mt-3 space-y-3 text-sm">
+              {recentProjects.map((project) => (
+                <li key={project.id} className="rounded-xl border p-3 dark:border-zinc-800">
+                  <p className="font-medium">{project.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {project.domains.length} domaines suivis • dernière mise à jour {formatRelative(project.updatedAt.toISOString())}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Dernière analyse {project.analyses[0]?.createdAt ? formatRelative(project.analyses[0].createdAt.toISOString()) : "jamais"}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  helper,
+}: {
+  label: string;
+  value: number;
+  helper?: string;
+}) {
+  return (
+    <div className="rounded-2xl border p-5 shadow-sm dark:border-zinc-800 dark:bg-zinc-950/40">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-3xl font-semibold">{value}</p>
+      {helper && <p className="mt-1 text-xs text-muted-foreground">{helper}</p>}
     </div>
   );
 }

--- a/src/app/(app)/projects/[id]/page.tsx
+++ b/src/app/(app)/projects/[id]/page.tsx
@@ -29,7 +29,15 @@ export default async function ProjectPage({ params }: PageProps) {
     prisma.domain.findMany({
       where: { projectId: id },
       orderBy: { createdAt: "desc" },
-      select: { id: true, name: true, notes: true, competitors: true, updatedAt: true },
+      select: {
+        id: true,
+        name: true,
+        notes: true,
+        competitors: true,
+        suggestions: true,
+        createdAt: true,
+        updatedAt: true,
+      },
     }),
   ]);
 

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -1,0 +1,140 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { PrismaClient } from "@prisma/client";
+import { authOptions } from "@/lib/authOptions";
+import { AnalysisReportSchema } from "@/types/analysis";
+import { summarizeAnalysis } from "@/lib/analysisSummary";
+
+const prisma = new PrismaClient();
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.group !== "ADMINISTRATEUR") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 1000 * 60 * 60 * 24 * 30);
+  const sixtyDaysAgo = new Date(now.getTime() - 1000 * 60 * 60 * 24 * 60);
+
+  const [
+    totalUsers,
+    totalProjects,
+    totalDomains,
+    totalAnalyses,
+    analysesLast30,
+    latestAnalyses,
+    domainRows,
+    llmKeys,
+    newUsersLast30,
+    latestUsers,
+  ] = await Promise.all([
+    prisma.user.count(),
+    prisma.project.count(),
+    prisma.domain.count(),
+    prisma.projectAnalysis.count(),
+    prisma.projectAnalysis.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
+    prisma.projectAnalysis.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        createdAt: true,
+        report: true,
+        project: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.domain.findMany({
+      select: {
+        id: true,
+        name: true,
+        competitors: true,
+        project: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.llmApiKey.findMany({
+      orderBy: { updatedAt: "desc" },
+      select: { provider: true, updatedAt: true },
+    }),
+    prisma.user.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
+    prisma.user.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: { id: true, email: true, group: true, createdAt: true },
+    }),
+  ]);
+
+  const analysisSummaries = latestAnalyses
+    .map((item) => {
+      const parsed = AnalysisReportSchema.safeParse(item.report);
+      if (!parsed.success) return null;
+      return {
+        id: item.id,
+        projectName: item.project.name,
+        createdAt: item.createdAt.toISOString(),
+        summary: summarizeAnalysis(parsed.data),
+      };
+    })
+    .filter((entry): entry is {
+      id: string;
+      projectName: string;
+      createdAt: string;
+      summary: ReturnType<typeof summarizeAnalysis>;
+    } => Boolean(entry));
+
+  const domainCoverage = domainRows.map((domain) => {
+    let competitors: string[] = [];
+    try {
+      const parsed = JSON.parse(domain.competitors);
+      competitors = Array.isArray(parsed) ? parsed.map((item) => String(item)).filter(Boolean) : [];
+    } catch {
+      competitors = [];
+    }
+    return {
+      id: domain.id,
+      name: domain.name,
+      projectName: domain.project.name,
+      competitorCount: competitors.length,
+    };
+  });
+
+  const coverageAlerts = domainCoverage
+    .filter((item) => item.competitorCount < 3)
+    .slice(0, 5);
+
+  const llmStale = llmKeys
+    .filter((key) => key.updatedAt < sixtyDaysAgo)
+    .map((key) => ({ provider: key.provider, updatedAt: key.updatedAt.toISOString() }));
+
+  return NextResponse.json({
+    totals: {
+      users: totalUsers,
+      projects: totalProjects,
+      domains: totalDomains,
+      analyses: totalAnalyses,
+    },
+    analyses: {
+      last30Days: analysesLast30,
+      latest: analysisSummaries,
+    },
+    domains: {
+      withoutCompetitors: domainCoverage.filter((item) => item.competitorCount === 0).length,
+      alerts: coverageAlerts,
+    },
+    llm: {
+      configured: llmKeys.length,
+      stale: llmStale,
+    },
+    users: {
+      newLast30Days,
+      latest: latestUsers.map((user) => ({
+        id: user.id,
+        email: user.email,
+        group: user.group,
+        createdAt: user.createdAt.toISOString(),
+      })),
+    },
+  });
+}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -128,7 +128,7 @@ export async function GET(req: Request) {
       stale: llmStale,
     },
     users: {
-      newLast30Days,
+      newLast30Days: newUsersLast30,
       latest: latestUsers.map((user) => ({
         id: user.id,
         email: user.email,

--- a/src/components/projects/AnalysisLauncher.tsx
+++ b/src/components/projects/AnalysisLauncher.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import AnalysisTabs from "@/components/projects/AnalysisTabs";
 import type { AnalysisReport } from "@/types/analysis";
+import { summarizeAnalysis, type AnalysisRunSummary } from "@/lib/analysisSummary";
+
+type AnalysisHistoryItem = {
+  id: string;
+  createdAt: string;
+  summary: AnalysisRunSummary;
+};
 
 type AnalysisApiResponse = {
   parsed?: AnalysisReport;
@@ -11,6 +18,9 @@ type AnalysisApiResponse = {
   chatPreview?: string;
   detail?: string;
   error?: string;
+  createdAt?: string;
+  history?: AnalysisHistoryItem[];
+  run?: AnalysisHistoryItem;
   [key: string]: unknown;
 };
 
@@ -19,6 +29,8 @@ export default function AnalysisLauncher({ projectId }: { projectId: string }) {
   const [data, setData] = useState<AnalysisReport | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [initializing, setInitializing] = useState(true);
+  const [history, setHistory] = useState<AnalysisHistoryItem[]>([]);
+  const [lastRunAt, setLastRunAt] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -35,9 +47,19 @@ export default function AnalysisLauncher({ projectId }: { projectId: string }) {
           throw new Error(`Impossible de récupérer l'analyse (${res.status})`);
         }
 
-        const payload = (await res.json()) as { parsed?: AnalysisReport };
-        if (!cancelled && payload?.parsed) {
+        const payload = (await res.json()) as AnalysisApiResponse;
+        if (cancelled) return;
+
+        if (payload?.parsed) {
           setData(payload.parsed);
+        }
+        if (payload?.history) {
+          setHistory(payload.history);
+        }
+        if (payload?.createdAt) {
+          setLastRunAt(payload.createdAt);
+        } else if (payload?.history?.length) {
+          setLastRunAt(payload.history[0].createdAt);
         }
       } catch (error: unknown) {
         console.error(error);
@@ -96,6 +118,13 @@ export default function AnalysisLauncher({ projectId }: { projectId: string }) {
       }
 
       setData(payload.parsed);
+      if (payload.run) {
+        setHistory((prev) => {
+          const next = [payload.run, ...prev.filter((item) => item.id !== payload.run?.id)];
+          return next.slice(0, 5);
+        });
+        setLastRunAt(payload.run.createdAt);
+      }
     } catch (error: unknown) {
       if (error instanceof Error) {
         setError(error.message);
@@ -107,23 +136,147 @@ export default function AnalysisLauncher({ projectId }: { projectId: string }) {
     }
   }
 
+  const summary = useMemo(() => (data ? summarizeAnalysis(data) : null), [data]);
+
+  function formatDateTime(iso?: string | null) {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "—";
+    return d.toLocaleString();
+  }
+
   return (
-    <div className="mt-6">
-      <Button onClick={run} disabled={loading || initializing}>
-        {loading
-          ? "Analyse en cours…"
-          : data
-            ? "Relancer l’analyse"
-            : "Lancer l’analyse"}
-      </Button>
+    <div className="mt-8 space-y-6">
+      <div className="rounded-2xl border p-5 dark:border-zinc-800 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Moteur d’analyse IA</p>
+            <h3 className="text-lg font-semibold">
+              {summary ? `Dernière exécution : ${formatDateTime(summary.generatedAt)}` : "Aucune analyse disponible"}
+            </h3>
+            {lastRunAt && (
+              <p className="text-xs text-muted-foreground">Enregistrée le {formatDateTime(lastRunAt)}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button onClick={run} disabled={loading || initializing}>
+              {loading ? "Analyse en cours…" : data ? "Relancer l’analyse" : "Lancer l’analyse"}
+            </Button>
+          </div>
+        </div>
 
-      {error && (
-        <p className="text-sm text-red-600 mt-3 whitespace-pre-wrap">
-          Erreur : {error}
-        </p>
+        {loading && (
+          <p className="text-sm text-muted-foreground">Collecte des signaux et génération de la synthèse…</p>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600 whitespace-pre-wrap">Erreur : {error}</p>
+        )}
+
+        {history.length > 1 && (
+          <div className="flex flex-wrap gap-4 text-xs text-muted-foreground">
+            <div>
+              {history.length} analyses archivées • dernière relance : {formatDateTime(history[0]?.createdAt)}
+            </div>
+            <div>
+              Taux moyen de mentions :
+              {" "}
+              {Math.round(
+                history.reduce((acc, item) => acc + (item.summary.mentionRate ?? 0), 0) / history.length
+              )}
+              %
+            </div>
+          </div>
+        )}
+      </div>
+
+      {summary && data && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <MetricCard
+              label="Sentiment global"
+              value={summary.sentiment}
+              tone={
+                summary.sentiment === "Positive"
+                  ? "positive"
+                  : summary.sentiment === "Négative"
+                  ? "negative"
+                  : summary.sentiment === "Mixte"
+                  ? "mixed"
+                  : "neutral"
+              }
+              helper={data.part1.sentimentGlobal.justification}
+            />
+            <MetricCard
+              label="Questions analysées"
+              value={`${summary.questionCount}`}
+              helper={`${summary.mentionYes} évoquent la marque (${summary.mentionRate}% de présence)`}
+            />
+            <MetricCard
+              label="Concurrents détectés"
+              value={`${summary.competitorCount}`}
+              helper={summary.competitorNames.length ? summary.competitorNames.join(", ") : "—"}
+            />
+            <MetricCard
+              label="Prochaine action recommandée"
+              value={data.part1.recommandations[0] ?? "—"}
+              helper={data.part1.recommandations[1] ?? ""}
+            />
+          </div>
+
+          {history.length > 0 && (
+            <div className="rounded-2xl border p-5 dark:border-zinc-800">
+              <h4 className="text-sm font-semibold">Historique des analyses</h4>
+              <ul className="mt-3 space-y-3 text-sm">
+                {history.map((item) => (
+                  <li key={item.id} className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{formatDateTime(item.summary.generatedAt)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.summary.mentionRate}% de visibilité • {item.summary.competitorCount} concurrents cités
+                      </p>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {item.summary.sentiment}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <AnalysisTabs data={data} />
+        </>
       )}
+    </div>
+  );
+}
 
-      {data && <AnalysisTabs data={data} />}
+function MetricCard({
+  label,
+  value,
+  helper,
+  tone = "neutral",
+}: {
+  label: string;
+  value: string;
+  helper?: string;
+  tone?: "neutral" | "positive" | "negative" | "mixed";
+}) {
+  const base =
+    tone === "positive"
+      ? "border-emerald-200 bg-emerald-50/60 text-emerald-900"
+      : tone === "negative"
+      ? "border-rose-200 bg-rose-50/60 text-rose-900"
+      : tone === "mixed"
+      ? "border-amber-200 bg-amber-50/60 text-amber-900"
+      : "border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-900";
+
+  return (
+    <div className={`rounded-2xl border p-4 transition ${base}`}>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+      {helper && <p className="mt-1 text-xs text-muted-foreground leading-5">{helper}</p>}
     </div>
   );
 }

--- a/src/components/projects/DomainCard.tsx
+++ b/src/components/projects/DomainCard.tsx
@@ -1,64 +1,328 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui/use-toast";
 import DomainEditDialog from "./DomainEditDialog";
+
+type CompetitorSuggestion = {
+  name: string;
+  website?: string;
+  reason?: string;
+};
+
+type DomainCardDomain = {
+  id: string;
+  name: string;
+  notes?: string | null;
+  competitors: string;
+  suggestions?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function parseCompetitors(value: string): string[] {
+  try {
+    const arr = JSON.parse(value);
+    return Array.isArray(arr) ? arr.map((item) => String(item)).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseSuggestions(value?: string | null): CompetitorSuggestion[] {
+  if (!value) return [];
+  try {
+    const arr = JSON.parse(value);
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .map((item) => {
+        if (!item) return null;
+        if (typeof item === "string") return { name: item };
+        const name = "name" in item ? String(item.name ?? "").trim() : String(item ?? "").trim();
+        if (!name) return null;
+        const suggestion: CompetitorSuggestion = { name };
+        if ("website" in item && item.website) suggestion.website = String(item.website);
+        if ("reason" in item && item.reason) suggestion.reason = String(item.reason);
+        return suggestion;
+      })
+      .filter((item): item is CompetitorSuggestion => Boolean(item));
+  } catch {
+    return [];
+  }
+}
+
+function formatRelativeTime(iso: string) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  const diff = date.getTime() - Date.now();
+  const ranges: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["year", 1000 * 60 * 60 * 24 * 365],
+    ["month", 1000 * 60 * 60 * 24 * 30],
+    ["day", 1000 * 60 * 60 * 24],
+    ["hour", 1000 * 60 * 60],
+    ["minute", 1000 * 60],
+  ];
+  const rtf = new Intl.RelativeTimeFormat("fr", { numeric: "auto" });
+  for (const [unit, ms] of ranges) {
+    if (Math.abs(diff) >= ms || unit === "minute") {
+      return rtf.format(Math.round(diff / ms), unit);
+    }
+  }
+  return rtf.format(Math.round(diff / 1000), "second");
+}
 
 export default function DomainCard({
   projectId,
   domain,
 }: {
   projectId: string;
-  domain: { id: string; name: string; notes?: string | null; competitors: string; updatedAt: string };
+  domain: DomainCardDomain;
 }) {
   const router = useRouter();
-  const comp = (() => {
-    try {
-      const a = JSON.parse(domain.competitors);
-      return Array.isArray(a) ? a : [];
-    } catch {
-      return [];
-    }
-  })();
+  const { toast } = useToast();
+
+  const baseCompetitors = useMemo(() => parseCompetitors(domain.competitors), [domain.competitors]);
+  const [competitors, setCompetitors] = useState<string[]>(baseCompetitors);
+  useEffect(() => {
+    setCompetitors(baseCompetitors);
+  }, [baseCompetitors, domain.id]);
+
+  const [suggestions, setSuggestions] = useState<CompetitorSuggestion[]>(
+    () => parseSuggestions(domain.suggestions)
+  );
+  const [loadingSuggestions, setLoadingSuggestions] = useState(false);
+  const [savingCompetitor, setSavingCompetitor] = useState<string | null>(null);
+  const [suggestionError, setSuggestionError] = useState<string | null>(null);
+
+  const competitorHealth = competitors.length === 0
+    ? { label: "Aucun concurrent suivi", tone: "warning" as const }
+    : competitors.length < 3
+      ? { label: "Couverture à renforcer", tone: "info" as const }
+      : { label: "Couverture solide", tone: "success" as const };
+
+  const notesItems = useMemo(() => {
+    if (!domain.notes) return [];
+    return domain.notes
+      .split(/\r?\n+/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }, [domain.notes]);
 
   async function del() {
     if (!confirm("Supprimer ce domaine d'activité ?")) return;
     const res = await fetch(`/api/projects/${projectId}/domains/${domain.id}`, { method: "DELETE" });
-    if (res.ok) router.refresh();
+    if (res.ok) {
+      toast({ title: "Domaine supprimé", description: domain.name });
+      router.refresh();
+    } else {
+      toast({ title: "Échec", description: "Impossible de supprimer ce domaine." });
+    }
+  }
+
+  async function refreshSuggestions() {
+    setLoadingSuggestions(true);
+    setSuggestionError(null);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/domains/suggest`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ type: "competitors", domainName: domain.name }),
+      });
+      if (!res.ok) {
+        throw new Error(`Status ${res.status}`);
+      }
+      const json: { items?: unknown } = await res.json();
+      const next: CompetitorSuggestion[] = Array.isArray(json.items)
+        ? json.items
+            .map((item: unknown) => {
+              if (typeof item === "string") {
+                const name = item.trim();
+                return name ? { name } : null;
+              }
+              if (item && typeof item === "object") {
+                const candidate = item as { name?: unknown; website?: unknown; reason?: unknown };
+                const name = String(candidate.name ?? "").trim();
+                if (!name) return null;
+                return {
+                  name,
+                  website: candidate.website ? String(candidate.website) : undefined,
+                  reason: candidate.reason ? String(candidate.reason) : undefined,
+                } satisfies CompetitorSuggestion;
+              }
+              return null;
+            })
+            .filter((item): item is CompetitorSuggestion => Boolean(item))
+        : [];
+      setSuggestions(next);
+
+      // Persist suggestions for future sessions
+      await fetch(`/api/projects/${projectId}/domains/${domain.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ suggestions: next }),
+      });
+    } catch (error) {
+      console.error(error);
+      setSuggestionError("Impossible de récupérer de nouvelles suggestions.");
+      toast({ title: "Suggestions indisponibles", description: "Réessayez dans quelques minutes." });
+    } finally {
+      setLoadingSuggestions(false);
+    }
+  }
+
+  async function addCompetitor(name: string) {
+    const trimmed = name.trim();
+    if (!trimmed || competitors.includes(trimmed)) return;
+    setSavingCompetitor(trimmed);
+    try {
+      const payload = [...new Set([...competitors, trimmed])];
+      const res = await fetch(`/api/projects/${projectId}/domains/${domain.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ competitors: payload }),
+      });
+      if (!res.ok) throw new Error(`Status ${res.status}`);
+      setCompetitors(payload);
+      toast({ title: "Concurrent ajouté", description: trimmed });
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      toast({ title: "Échec", description: "Impossible d'ajouter ce concurrent." });
+    } finally {
+      setSavingCompetitor(null);
+    }
   }
 
   return (
-    <div className="rounded-2xl border p-4 dark:border-zinc-800">
-      <div className="flex items-start justify-between">
-        <h3 className="text-lg font-semibold">{domain.name}</h3>
-        <span className="text-xs opacity-60">
-          Updated {new Date(domain.updatedAt).toLocaleString()}
+    <div className="rounded-2xl border p-5 dark:border-zinc-800 space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold">{domain.name}</h3>
+          <p className="text-xs text-muted-foreground">
+            Mis à jour {formatRelativeTime(domain.updatedAt)} • Créé {formatRelativeTime(domain.createdAt)}
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${
+            competitorHealth.tone === "success"
+              ? "bg-emerald-100 text-emerald-700"
+              : competitorHealth.tone === "info"
+              ? "bg-amber-100 text-amber-700"
+              : "bg-rose-100 text-rose-700"
+          }`}
+        >
+          {competitorHealth.tone === "success" ? "🟢" : competitorHealth.tone === "info" ? "🟠" : "🔴"}
+          {competitorHealth.label}
         </span>
       </div>
 
-      {domain.notes && <p className="mt-2 text-sm">{domain.notes}</p>}
-
-      {!!comp.length && (
-        <div className="mt-3">
-          <div className="text-xs font-medium opacity-70 mb-1">CONCURRENTS</div>
-          <div className="flex flex-wrap gap-2">
-            {comp.map((c: string) => (
-              <span key={c} className="rounded-full bg-gray-100 px-2 py-1 text-xs dark:bg-zinc-800">
-                {c}
-              </span>
+      {notesItems.length > 0 && (
+        <div className="rounded-xl border border-dashed p-4 dark:border-zinc-700">
+          <h4 className="text-sm font-semibold mb-2">Notes terrain</h4>
+          <ul className="list-disc space-y-1 pl-5 text-sm leading-6">
+            {notesItems.map((item) => (
+              <li key={item}>{item}</li>
             ))}
-          </div>
+          </ul>
         </div>
       )}
 
-      <div className="mt-4 flex items-center gap-4 text-sm">
-        {/* 👇 Le bouton Edit ouvre maintenant un drawer fonctionnel */}
-        <DomainEditDialog projectId={projectId} domain={domain as any} />
-        <button
-          onClick={del}
-          className="inline-flex items-center gap-1 text-red-600 opacity-80 hover:opacity-100"
-        >
-          <span>🗑️</span> Delete
-        </button>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border p-4 dark:border-zinc-800">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold">Concurrents suivis ({competitors.length})</h4>
+            <DomainEditDialog projectId={projectId} domain={domain as any} />
+          </div>
+
+          {competitors.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Aucun concurrent enregistré pour le moment. Utilisez les suggestions IA pour démarrer la veille.
+            </p>
+          ) : (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {competitors.map((name) => (
+                <span
+                  key={name}
+                  className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium dark:bg-zinc-800"
+                >
+                  {name}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-xl border p-4 dark:border-zinc-800">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold">Suggestions IA</h4>
+            <button
+              onClick={refreshSuggestions}
+              className="rounded-lg border px-3 py-1.5 text-xs font-medium hover:bg-gray-50 dark:hover:bg-zinc-800"
+            >
+              {loadingSuggestions ? "Analyse…" : "Mettre à jour"}
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Génère une short-list automatique à partir des signaux récents. Ajoutez-les en un clic au suivi.
+          </p>
+
+          {suggestionError && (
+            <p className="mt-2 text-xs text-rose-600">{suggestionError}</p>
+          )}
+
+          {suggestions.length === 0 ? (
+            <p className="mt-3 text-sm text-muted-foreground">
+              Aucune suggestion disponible pour l’instant.
+            </p>
+          ) : (
+            <ul className="mt-3 space-y-3">
+              {suggestions.map((item) => (
+                <li key={item.name} className="rounded-lg border border-dashed p-3 text-sm dark:border-zinc-700">
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium">{item.name}</p>
+                      {item.website && (
+                        <a
+                          href={item.website}
+                          target="_blank"
+                          className="text-xs text-blue-600 hover:underline"
+                          rel="noreferrer"
+                        >
+                          {item.website}
+                        </a>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => addCompetitor(item.name)}
+                      disabled={savingCompetitor === item.name}
+                      className="rounded-lg bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-60"
+                    >
+                      {savingCompetitor === item.name ? "Ajout…" : "Suivre"}
+                    </button>
+                  </div>
+                  {item.reason && (
+                    <p className="mt-2 text-xs text-muted-foreground leading-5">{item.reason}</p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div className="text-xs text-muted-foreground">
+          Piloté depuis {formatRelativeTime(domain.createdAt)}
+        </div>
+        <div className="flex items-center gap-4">
+          <button
+            onClick={del}
+            className="inline-flex items-center gap-1 text-sm text-rose-600 hover:text-rose-700"
+          >
+            <span>🗑️</span> Supprimer
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/analysisSummary.ts
+++ b/src/lib/analysisSummary.ts
@@ -1,0 +1,35 @@
+import type { AnalysisReport } from "@/types/analysis";
+
+export type AnalysisRunSummary = {
+  generatedAt: string;
+  sentiment: AnalysisReport["part1"]["sentimentGlobal"]["label"];
+  questionCount: number;
+  mentionYes: number;
+  mentionRate: number;
+  competitorCount: number;
+  competitorNames: string[];
+};
+
+export function summarizeAnalysis(report: AnalysisReport): AnalysisRunSummary {
+  const questionCount = report.part3.questions.length;
+  const mentionYes = report.part3.questions.filter((q) => q.mentionProbable === "Oui").length;
+  const competitorNames = Array.from(
+    new Set(
+      report.part3.questions.flatMap((q) =>
+        (q.concurrentsCites ?? []).map((name) => name.trim()).filter(Boolean)
+      )
+    )
+  );
+
+  const mentionRate = questionCount === 0 ? 0 : Math.round((mentionYes / questionCount) * 100);
+
+  return {
+    generatedAt: report.meta.generatedAt,
+    sentiment: report.part1.sentimentGlobal.label,
+    questionCount,
+    mentionYes,
+    mentionRate,
+    competitorCount: competitorNames.length,
+    competitorNames,
+  };
+}


### PR DESCRIPTION
## Summary
- transform the dashboard into a data-rich cockpit with usage metrics, recent analyses, and competitive coverage insights driven by Prisma aggregates
- enrich domain cards with health indicators, persistent AI suggestions, and quick actions to bolster competitor tracking workflows
- mature the LLM analysis launcher by exposing execution history, actionable KPIs, and shared summarisation utilities for reuse
- extend the superadmin console with global statistics, activity alerts, and stale key warnings powered by a new admin stats API endpoint

## Testing
- npm run lint *(fails: existing repository-wide lint issues around any usage and JSX apostrophes; see run output)*

------
https://chatgpt.com/codex/tasks/task_e_68d509222b808330bf54c1fe66a8132c