### PR TITLE
Enhance dashboard trends and enrich competitor suggestions

### DIFF
--- a/src/components/projects/DomainCreateDialog.tsx
+++ b/src/components/projects/DomainCreateDialog.tsx
@@ -42,7 +42,72 @@ function normalizeList(raw: unknown): string[] {
     .filter(Boolean);
 }
 
-type CompetitorObj = { name: string; website?: string; reason?: string };
+type CompetitorObj = {
+  name: string;
+  website?: string;
+  reason?: string;
+  confidence?: number;
+  signals?: string[];
+  source?: string;
+};
+
+function normalizeSuggestion(value: unknown): CompetitorObj | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    const name = value.trim();
+    return name ? { name } : null;
+  }
+  if (typeof value === "object") {
+    const candidate = value as {
+      name?: unknown;
+      website?: unknown;
+      reason?: unknown;
+      confidence?: unknown;
+      signals?: unknown;
+      source?: unknown;
+    };
+    const name = String(candidate.name ?? "").trim();
+    if (!name) return null;
+    const suggestion: CompetitorObj = { name };
+    if (candidate.website) suggestion.website = String(candidate.website);
+    if (candidate.reason) suggestion.reason = String(candidate.reason);
+    if (typeof candidate.confidence === "number" && Number.isFinite(candidate.confidence)) {
+      suggestion.confidence = Math.max(0, Math.min(100, Math.round(candidate.confidence)));
+    }
+    if (Array.isArray(candidate.signals)) {
+      const signals = candidate.signals.map((signal) => String(signal).trim()).filter(Boolean);
+      if (signals.length) suggestion.signals = Array.from(new Set(signals));
+    }
+    if (candidate.source) suggestion.source = String(candidate.source);
+    return suggestion;
+  }
+  return null;
+}
+
+function confidenceTextClass(score?: number) {
+  if ((score ?? 0) >= 75) return "text-emerald-600";
+  if ((score ?? 0) >= 55) return "text-amber-600";
+  return "text-rose-600";
+}
+
+function confidenceBarClass(score?: number) {
+  if ((score ?? 0) >= 75) return "bg-emerald-500";
+  if ((score ?? 0) >= 55) return "bg-amber-500";
+  return "bg-rose-500";
+}
+
+function displayConfidence(score?: number) {
+  if (typeof score !== "number" || Number.isNaN(score)) return 50;
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+function describeSource(source?: string) {
+  if (!source) return "IA générative";
+  if (source.includes("gpt4o")) return "GPT-4o + Web";
+  if (source.includes("o3")) return "OpenAI o3";
+  if (source.includes("gpt4mini")) return "GPT-4o-mini";
+  return source;
+}
 
 export default function DomainCreateDialog({ projectId }: { projectId: string }) {
   const { toast } = useToast();
@@ -62,6 +127,12 @@ export default function DomainCreateDialog({ projectId }: { projectId: string })
 
   const [loadingCompetitors, setLoadingCompetitors] = useState(false);
   const [competitorSuggestions, setCompetitorSuggestions] = useState<CompetitorObj[]>([]);
+  const [suggestionsMeta, setSuggestionsMeta] = useState<{
+    source?: string;
+    webSearchUsed?: boolean;
+    executionTime?: string;
+    averageConfidence?: number | null;
+  } | null>(null);
 
   function addCompetitor() {
     const v = competitorInput.trim();
@@ -98,6 +169,7 @@ export default function DomainCreateDialog({ projectId }: { projectId: string })
     }
     setLoadingCompetitors(true);
     setCompetitorSuggestions([]);
+    setSuggestionsMeta(null);
     try {
       const res = await fetch(`/api/projects/${projectId}/domains/suggest`, {
         method: "POST",
@@ -105,10 +177,25 @@ export default function DomainCreateDialog({ projectId }: { projectId: string })
         body: JSON.stringify({ type: "competitors", domainName: name.trim() }),
       });
       const j = await res.json();
-      const items: CompetitorObj[] = Array.isArray(j.items) ? j.items : [];
+      const meta = {
+        source: typeof j.source === "string" ? j.source : undefined,
+        webSearchUsed: typeof j.webSearchUsed === "boolean" ? j.webSearchUsed : undefined,
+        executionTime: typeof j.executionTime === "string" ? j.executionTime : undefined,
+        averageConfidence:
+          typeof j.averageConfidence === "number" && Number.isFinite(j.averageConfidence)
+            ? Math.round(j.averageConfidence)
+            : undefined,
+      };
+      setSuggestionsMeta(meta);
+      const items: CompetitorObj[] = Array.isArray(j.items)
+        ? j.items
+            .map((item: unknown) => normalizeSuggestion(item))
+            .filter((item): item is CompetitorObj => Boolean(item))
+        : [];
       setCompetitorSuggestions(items);
     } catch {
       toast({ title: "Échec", description: "Impossible d'obtenir des concurrents suggérés" });
+      setSuggestionsMeta(null);
     } finally {
       setLoadingCompetitors(false);
     }
@@ -265,39 +352,91 @@ export default function DomainCreateDialog({ projectId }: { projectId: string })
               </p>
 
               {!!competitorSuggestions.length && (
-                <div className="mt-3 flex flex-col gap-2">
-                  {competitorSuggestions.map((c) => (
-                    <div
-                      key={`${c.name}-${c.website ?? ""}`}
-                      className="flex items-center justify-between gap-3 rounded-xl border px-3 py-2 text-sm dark:border-zinc-800"
-                      title={c.reason || ""}
-                    >
-                      <div className="min-w-0">
-                        <div className="font-medium truncate">{c.name}</div>
-                        {c.website && (
-                          <a
-                            className="text-xs underline opacity-80"
-                            href={c.website}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            {c.website}
-                          </a>
-                        )}
-                        {c.reason && (
-                          <div className="text-xs opacity-70 line-clamp-2">{c.reason}</div>
-                        )}
-                      </div>
-                      <button
-                        onClick={() =>
-                          setCompetitors((prev) => (prev.includes(c.name) ? prev : [...prev, c.name]))
-                        }
-                        className="shrink-0 rounded-lg border px-3 py-1 hover:bg-gray-50 dark:hover:bg-zinc-800"
+                <div className="mt-3 flex flex-col gap-2 text-sm">
+                  {suggestionsMeta && (
+                    <div className="text-xs text-muted-foreground">
+                      Source : {describeSource(suggestionsMeta.source)}
+                      {typeof suggestionsMeta.webSearchUsed === "boolean" && (
+                        <span className="ml-2 inline-flex items-center gap-1 rounded-full border border-zinc-200 px-2 py-[2px] text-[10px] uppercase tracking-wide dark:border-zinc-700">
+                          {suggestionsMeta.webSearchUsed ? "Web search" : "Sans web"}
+                        </span>
+                      )}
+                  {suggestionsMeta.executionTime && (
+                    <span className="ml-2">• {suggestionsMeta.executionTime}</span>
+                  )}
+                  {typeof suggestionsMeta.averageConfidence === "number" && (
+                    <span className="ml-2">• Score moyen {suggestionsMeta.averageConfidence}%</span>
+                  )}
+                </div>
+              )}
+                  {competitorSuggestions.map((c) => {
+                    const confidence = displayConfidence(c.confidence);
+                    const sourceLabel = describeSource(c.source ?? suggestionsMeta?.source);
+                    return (
+                      <div
+                        key={`${c.name}-${c.website ?? ""}`}
+                        className="rounded-xl border px-3 py-2 dark:border-zinc-800"
                       >
-                        Ajouter
-                      </button>
-                    </div>
-                  ))}
+                        <div className="flex flex-col gap-2">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 space-y-1">
+                              <div className="font-medium leading-tight">
+                                {c.name}
+                              </div>
+                              {c.website && (
+                                <a
+                                  className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                                  href={c.website}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
+                                  {c.website}
+                                </a>
+                              )}
+                              {!!c.signals?.length && (
+                                <div className="flex flex-wrap gap-1 pt-1">
+                                  {c.signals.map((signal) => (
+                                    <span
+                                      key={`${c.name}-${signal}`}
+                                      className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-[2px] text-[10px] font-medium uppercase tracking-wide text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
+                                    >
+                                      {signal}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            <div className="flex w-[88px] flex-col items-end gap-1">
+                              <div className={`flex items-center gap-1 text-xs ${confidenceTextClass(c.confidence)}`}>
+                                <span>Confiance</span>
+                                <span className="font-semibold">{confidence}%</span>
+                              </div>
+                              <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                                <div
+                                  className={`${confidenceBarClass(c.confidence)} h-full rounded-full`}
+                                  style={{ width: `${Math.max(4, confidence)}%` }}
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          {c.reason && (
+                            <div className="text-xs leading-5 text-muted-foreground">{c.reason}</div>
+                          )}
+                          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                            <span>{sourceLabel}</span>
+                            <button
+                              onClick={() =>
+                                setCompetitors((prev) => (prev.includes(c.name) ? prev : [...prev, c.name]))
+                              }
+                              className="shrink-0 rounded-lg border px-3 py-1 hover:bg-gray-50 dark:hover:bg-zinc-800"
+                            >
+                              Ajouter
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add 30-day time-series helpers and sparkline visuals to the dashboard KPIs to surface momentum on projects, domains, analyses and coverage updates
- display richer AI competitor suggestions with confidence gauges, signal tags and source metadata in both the domain card and creation dialog
- enrich the competitor suggestion API by computing heuristic confidence scores, deriving signal tags and returning summary metadata for the UI

## Testing
- `npm run lint` *(fails due to numerous pre-existing lint issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d539aa5a4c83309e6ec6baffa94689