### PR TITLE
feat: switch analysis generation to gpt-5

### DIFF
--- a/src/app/api/projects/[id]/analysis/route.ts
+++ b/src/app/api/projects/[id]/analysis/route.ts
@@ -747,7 +747,9 @@ export async function POST(
         content: [{ type: "input_text", text: prompt }],
       },
     ],
-    response_format: ANALYSIS_RESPONSE_FORMAT,
+    text: {
+      format: ANALYSIS_RESPONSE_FORMAT,
+    },
     reasoning: {},
     tools: [
       {


### PR DESCRIPTION
## Summary
- switch the analysis generation endpoint to the gpt-5 model with the Responses API
- enforce the expected report contract with a json schema response format and capture structured payloads before falling back to text parsing

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d696aa56d883308d72521919e0122c